### PR TITLE
Improve validation and autoloading

### DIFF
--- a/aivalidationhandler.php
+++ b/aivalidationhandler.php
@@ -1,27 +1,56 @@
 <?php
-require_once __DIR__ . '/promptApiProcessor.php';
-require_once __DIR__ . '/ipRateLimiter.php';
-require_once __DIR__ . '/requestErrorLogManager.php';
-require_once __DIR__ . '/defineOpenRouterApiKey.php';
+require_once __DIR__ . '/vendor/autoload.php';
+
+use QuickIdeaValidator\Logging\RequestErrorLogManager;
 
 session_start();
 
-header('Content-Type: application/json; charset=utf-8');
+$isAjax = strtolower($_SERVER['HTTP_X_REQUESTED_WITH'] ?? '') === 'xmlhttprequest';
+
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    header('Content-Type: application/json; charset=utf-8');
     http_response_code(405);
     echo json_encode(['error' => 'Method not allowed']);
     exit;
 }
 
-$csrfHeader = $_SERVER['HTTP_X_CSRF_TOKEN'] ?? '';
+$csrfHeader = $_SERVER['HTTP_X_CSRF_TOKEN'] ?? ($_POST['csrf_token'] ?? '');
 if (!isset($_SESSION['csrf_token']) || !hash_equals($_SESSION['csrf_token'], $csrfHeader)) {
+    header('Content-Type: application/json; charset=utf-8');
     http_response_code(403);
     echo json_encode(['error' => 'Invalid CSRF token']);
     exit;
 }
 
+if (!$isAjax && isset($_POST['idea'])) {
+    header('Content-Type: text/html; charset=utf-8');
+    $idea = sanitizeIdea($_POST['idea']);
+    try {
+        $ip = $_SERVER['REMOTE_ADDR'] ?? '0.0.0.0';
+        enforceRateLimit($ip);
+
+        $instruction = buildInstruction();
+        $apiResp = callOpenRouterAPI($instruction, $idea);
+        $parsed = parseAIResponse($apiResp);
+
+        $message = strtoupper($parsed['verdict']) === 'YES' ? 'Your idea looks good!' : 'Sorry, that idea may not work.';
+        echo "<p>{$message}</p>";
+    } catch (Throwable $e) {
+        $logger = new RequestErrorLogManager();
+        $logger->logError($e->getCode(), $e->getMessage(), [ 'payload' => $_POST ]);
+        http_response_code(500);
+        echo '<p>Server error</p>';
+    }
+    exit;
+}
+
 $raw = file_get_contents('php://input');
 $data = json_decode($raw, true);
+if (json_last_error() !== JSON_ERROR_NONE) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Malformed request body']);
+    exit;
+}
 $idea = sanitizeIdea($data['idea'] ?? '');
 if ($idea === '') {
     http_response_code(400);

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,12 @@
+{
+  "autoload": {
+    "psr-4": {
+      "QuickIdeaValidator\\": "src/"
+    },
+    "files": [
+      "promptApiProcessor.php",
+      "ipRateLimiter.php",
+      "defineOpenRouterApiKey.php"
+    ]
+  }
+}

--- a/formSubmissionController.js
+++ b/formSubmissionController.js
@@ -8,7 +8,6 @@ const csrfToken = csrfTokenInput ? csrfTokenInput.value : '';
 function debounce(fn, delay) {
   let timer = null;
   return function (...args) {
-    fn.apply(this, args);
     clearTimeout(timer);
     timer = setTimeout(() => {
       fn.apply(this, args);

--- a/index.php
+++ b/index.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/vendor/autoload.php';
 session_start();
 if (empty($_SESSION['csrf_token'])) {
     $_SESSION['csrf_token'] = bin2hex(random_bytes(32));

--- a/logs/.htaccess
+++ b/logs/.htaccess
@@ -1,0 +1,1 @@
+Deny from all

--- a/promptApiProcessor.php
+++ b/promptApiProcessor.php
@@ -1,4 +1,4 @@
-require_once __DIR__ . '/requestErrorLogManager.php';
+use QuickIdeaValidator\Logging\RequestErrorLogManager;
 
 function sanitizeIdea(string $idea): string {
     $clean = strip_tags($idea);

--- a/src/Logging/RequestErrorLogManager.php
+++ b/src/Logging/RequestErrorLogManager.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace QuickIdeaValidator\Logging;
+
 class RequestErrorLogManager
 {
     private string $logFilePath;

--- a/vendor/autoload.php
+++ b/vendor/autoload.php
@@ -1,0 +1,25 @@
+<?php
+spl_autoload_register(function ($class) {
+    $prefix = 'QuickIdeaValidator\\';
+    $baseDir = __DIR__ . '/../src/';
+    $len = strlen($prefix);
+    if (strncmp($prefix, $class, $len) !== 0) {
+        return;
+    }
+    $relativeClass = substr($class, $len);
+    $file = $baseDir . str_replace('\\', '/', $relativeClass) . '.php';
+    if (is_file($file)) {
+        require $file;
+    }
+});
+
+foreach ([
+    __DIR__ . '/../promptApiProcessor.php',
+    __DIR__ . '/../ipRateLimiter.php',
+    __DIR__ . '/../defineOpenRouterApiKey.php'
+] as $file) {
+    if (is_file($file)) {
+        require_once $file;
+    }
+}
+


### PR DESCRIPTION
## Summary
- add composer-style autoloader and PSR-4 namespace
- validate JSON bodies and handle plain POST fallback
- tweak debounce helper to fire on trailing edge
- include vendor autoload on entry point
- secure logs directory with `.htaccess`

## Testing
- `php -l aivalidationhandler.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856f31c70d8832789cdbca1f96065e7