### PR TITLE
Update OpenRouter integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,5 +7,5 @@ Quick Idea Validator is a lightweight PHP and JavaScript tool that uses the Open
 
 ## Usage
 1. Run `composer install` to install PHP dependencies.
-2. Create a `.env` file and set your `OPENROUTER_API_KEY`.
+2. Edit `defineOpenRouterApiKey.php` and replace `'orkey-your-token'` with your actual OpenRouter API key.
 3. Open `index.php` in your browser.

--- a/defineOpenRouterApiKey.php
+++ b/defineOpenRouterApiKey.php
@@ -1,48 +1,5 @@
 <?php
 if (!defined('OPENROUTER_API_KEY')) {
-    try {
-        // 1. Retrieve API key from environment variables
-        $key = getenv('OPENROUTER_API_KEY');
-        if ($key === false || $key === '') {
-            $key = $_ENV['OPENROUTER_API_KEY'] ?? $_SERVER['OPENROUTER_API_KEY'] ?? null;
-        }
-
-        // 2. If not found in environment, load from config.json
-        if (empty($key)) {
-            $configPath = __DIR__ . '/config.json';
-            if (!is_readable($configPath)) {
-                throw new Exception("Configuration file not found at {$configPath}");
-            }
-            $content = file_get_contents($configPath);
-            $config = json_decode($content, true);
-            if (json_last_error() !== JSON_ERROR_NONE) {
-                throw new Exception('Invalid JSON in configuration file: ' . json_last_error_msg());
-            }
-            if (empty($config['openrouter_api_key'])) {
-                throw new Exception('Missing openrouter_api_key in configuration file');
-            }
-            $key = $config['openrouter_api_key'];
-        }
-
-        $key = trim($key);
-
-        // 3. Validate API key format (starts with 'orkey-' followed by 10?120 valid chars)
-        if (!preg_match('/^orkey-[A-Za-z0-9_-]{10,120}$/', $key)) {
-            throw new Exception('OpenRouter API key does not match expected format');
-        }
-
-        // 4. Define constant for use by caller
-        define('OPENROUTER_API_KEY', $key);
-
-        // 5. Sync environment so consumers using getenv() get the same key
-        putenv('OPENROUTER_API_KEY=' . $key);
-        $_ENV['OPENROUTER_API_KEY'] = $key;
-        $_SERVER['OPENROUTER_API_KEY'] = $key;
-
-    } catch (Exception $e) {
-        // Log detailed error server-side
-        error_log('[OpenRouterConfig] ' . $e->getMessage());
-        // Throw generic exception for caller to handle HTTP response or other logic
-        throw new RuntimeException('Failed to load OpenRouter API key');
-    }
+    // Hard-coded API key used for OpenRouter requests.
+    define('OPENROUTER_API_KEY', 'orkey-your-token');
 }

--- a/promptApiProcessor.php
+++ b/promptApiProcessor.php
@@ -22,15 +22,16 @@ function buildInstruction(): string {
 
 function callOpenRouterAPI(string $instruction, string $idea): array {
     $logger = new RequestErrorLogManager();
-    $apiKey = getenv('OPENROUTER_API_KEY');
+    // Hard-coded API token. Replace with your actual token.
+    $apiKey = defined('OPENROUTER_API_KEY') ? OPENROUTER_API_KEY : 'orkey-your-token';
     if (empty($apiKey)) {
         $logger->logError(500, 'Missing OpenRouter API key');
         throw new Exception('Missing OpenRouter API key.');
     }
 
-    $url = 'https://openrouter.ai/v1/chat/completions';
+    $url = 'https://openrouter.ai/api/v1/chat/completions';
     $payload = [
-        'model'       => 'gpt-3.5-turbo',
+        'model'       => 'openai/gpt-4o-mini',
         'messages'    => [
             ['role' => 'system', 'content' => $instruction],
             ['role' => 'user',   'content' => $idea],
@@ -46,6 +47,8 @@ function callOpenRouterAPI(string $instruction, string $idea): array {
         CURLOPT_HTTPHEADER      => [
             'Content-Type: application/json',
             'Authorization: Bearer ' . $apiKey,
+            'HTTP-Referer: https://www.example.com',
+            'X-Title: Quick Idea Validator',
         ],
         CURLOPT_POSTFIELDS      => json_encode($payload),
         CURLOPT_CONNECTTIMEOUT  => 5,


### PR DESCRIPTION
## Summary
- update OpenRouter request to use `/api/v1` endpoint
- hard-code token and update model to `openai/gpt-4o-mini`
- send required HTTP-Referer and X-Title headers
- simplify API key definition
- document new setup steps

## Testing
- `composer validate --no-check-lock` *(fails: composer not installed)*
- `php -l promptApiProcessor.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6856f547917483278dedea50c65605fc