### PR TITLE
Add banner and improve whitespace handling

### DIFF
--- a/public/assets/formSubmissionController.js
+++ b/public/assets/formSubmissionController.js
@@ -16,9 +16,7 @@ function debounce(fn, delay) {
 }
 
 function sanitize(input) {
-  const div = document.createElement('div');
-  div.textContent = input;
-  return div.innerHTML.trim();
+  return input.replace(/<[^>]*>/g, '');
 }
 
 function clearResultClasses() {
@@ -32,7 +30,7 @@ function validateInput(e) {
     e.target.value = clean;
     raw = clean;
   }
-  if (clean.length < 3) {
+  if (clean.trim().length < 3) {
     submitBtn.disabled = true;
     clearResultClasses();
     resultBox.classList.add('info', 'visible');
@@ -89,7 +87,7 @@ function renderResult(data) {
 function sendIdeaToServer(e) {
   if (e && e.preventDefault) e.preventDefault();
   const idea = sanitize(ideaInput.value);
-  if (!idea) {
+  if (idea.trim().length === 0) {
     showError('Idea cannot be empty.');
     return;
   }

--- a/public/assets/responsiveFormComponents.css
+++ b/public/assets/responsiveFormComponents.css
@@ -36,6 +36,13 @@ body {
   margin-bottom: 1rem;
 }
 
+.banner-img {
+  display: block;
+  margin: 0 auto 1rem;
+  max-width: 100%;
+  height: auto;
+}
+
 .instructions {
   margin-top: 0.5rem;
   opacity: 0.85;

--- a/public/index.php
+++ b/public/index.php
@@ -22,6 +22,9 @@ $csrf_token = $_SESSION['csrf_token'];
   </header>
 
   <main class="app-main">
+  <header class="site-header">
+    <img src="assets/images/quick-idea-validator-banner.png" alt="Quick Idea Validator" class="banner-img" />
+  </header>
   <form id="ideaForm" class="idea-form" action="api/validate.php" method="post" novalidate>
     <label for="ideaInput" class="sr-only">Describe your idea</label>
     <textarea


### PR DESCRIPTION
## Summary
- add banner image above form
- center banner with `.banner-img` style
- sanitize by stripping HTML tags only
- count visible characters in validation
- remove duplicate banner asset

## Testing
- `npm test` *(fails: Could not read package.json)*
- `composer -n test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856fc08f63483279b17d0a836478dda