### PR TITLE
Add hardcoded OpenRouter key

### DIFF
--- a/defineOpenRouterApiKey.php
+++ b/defineOpenRouterApiKey.php
@@ -3,5 +3,7 @@ if (!defined('OPENROUTER_API_KEY')) {
     $envKey = getenv('OPENROUTER_API_KEY');
     if ($envKey !== false && $envKey !== '') {
         define('OPENROUTER_API_KEY', $envKey);
+    } else {
+        define('OPENROUTER_API_KEY', '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');
     }
 }


### PR DESCRIPTION
## Summary
- default OpenRouter API key added in `defineOpenRouterApiKey.php` if no env var is set

## Testing
- `composer install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857067c28a88327bb792ce20612fb8b