### PR TITLE
Configure autoload helpers via composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,9 +4,10 @@
       "QuickIdeaValidator\\": "src/"
     },
     "files": [
+      "defineOpenRouterApiKey.php",
       "src/AI/promptApiProcessor.php",
-      "src/RateLimit/ipRateLimiter.php",
-      "defineOpenRouterApiKey.php"
+      "src/AI/responseParser.php",
+      "src/RateLimit/ipRateLimiter.php"
     ]
   }
 }

--- a/public/api/validate.php
+++ b/public/api/validate.php
@@ -1,8 +1,7 @@
 <?php
 require __DIR__ . '/../../vendor/autoload.php';
-require __DIR__ . '/../../defineOpenRouterApiKey.php';
-
 use QuickIdeaValidator\Logging\RequestErrorLogManager;
+
 
 session_start();
 header('Content-Type: application/json; charset=utf-8');

--- a/src/AI/promptApiProcessor.php
+++ b/src/AI/promptApiProcessor.php
@@ -47,8 +47,6 @@ function callOpenRouterAPI(string $instruction, string $idea): array {
         CURLOPT_HTTPHEADER      => [
             'Content-Type: application/json',
             'Authorization: Bearer ' . $apiKey,
-            'HTTP-Referer: https://www.example.com',
-            'X-Title: Quick Idea Validator',
         ],
         CURLOPT_POSTFIELDS      => json_encode($payload),
         CURLOPT_CONNECTTIMEOUT  => 5,
@@ -95,31 +93,3 @@ function callOpenRouterAPI(string $instruction, string $idea): array {
     return $data;
 }
 
-function parseAIResponse(array $apiResp): array {
-    $content = trim($apiResp['choices'][0]['message']['content']);
-
-    // Split into verdict part and tips part
-    $parts = preg_split('/\bTips[:\-]?\b/i', $content, 2);
-    $verdictPart = $parts[0] ?? '';
-    $tipsPart    = $parts[1] ?? '';
-
-    // Extract verdict
-    if (preg_match('/\bVerdict[:\-]?\s*(YES|NO)\b/i', $verdictPart, $m)) {
-        $verdict = strtoupper($m[1]);
-    } else {
-        // Fallback to first non-empty line
-        $lines = preg_split('/\r?\n/', trim($verdictPart));
-        $verdict = strtoupper(trim($lines[0] ?? ''));
-    }
-
-    // Clean and split tips
-    $tipsRaw = trim($tipsPart);
-    $tipsArray = preg_split('/(?:;|\r?\n)+/', $tipsRaw);
-    $tipsArray = array_filter(array_map('trim', $tipsArray));
-
-    return [
-        'verdict' => $verdict,
-        'tips'    => array_values($tipsArray),
-        'raw'     => $content,
-    ];
-}

--- a/src/AI/responseParser.php
+++ b/src/AI/responseParser.php
@@ -1,0 +1,29 @@
+<?php
+function parseAIResponse(array $apiResp): array {
+    $content = trim($apiResp['choices'][0]['message']['content']);
+
+    // Split into verdict part and tips part
+    $parts = preg_split('/\bTips[:\-]?\b/i', $content, 2);
+    $verdictPart = $parts[0] ?? '';
+    $tipsPart    = $parts[1] ?? '';
+
+    // Extract verdict
+    if (preg_match('/\bVerdict[:\-]?\s*(YES|NO)\b/i', $verdictPart, $m)) {
+        $verdict = strtoupper($m[1]);
+    } else {
+        // Fallback to first non-empty line
+        $lines = preg_split('/\r?\n/', trim($verdictPart));
+        $verdict = strtoupper(trim($lines[0] ?? ''));
+    }
+
+    // Clean and split tips
+    $tipsRaw = trim($tipsPart);
+    $tipsArray = preg_split('/(?:;|\r?\n)+/', $tipsRaw);
+    $tipsArray = array_filter(array_map('trim', $tipsArray));
+
+    return [
+        'verdict' => $verdict,
+        'tips'    => array_values($tipsArray),
+        'raw'     => $content,
+    ];
+}


### PR DESCRIPTION
## Summary
- autoload helper functions via Composer files directive
- simplify API entrypoint bootstrapping
- move response parsing helper into its own file
- clean headers for OpenRouter API request

## Testing
- `composer dump-autoload` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68570b29673483278261a93b0da54937