### PR TITLE
Fix RequestErrorLogManager imports and rate limiter log path

### DIFF
--- a/src/Logging/RequestErrorLogManager.php
+++ b/src/Logging/RequestErrorLogManager.php
@@ -2,6 +2,10 @@
 
 namespace QuickIdeaValidator\Logging;
 
+use InvalidArgumentException;
+use RuntimeException;
+use Throwable;
+
 class RequestErrorLogManager
 {
     private string $logFilePath;

--- a/src/RateLimit/ipRateLimiter.php
+++ b/src/RateLimit/ipRateLimiter.php
@@ -20,7 +20,8 @@ function enforceRateLimit(string $ip): void
     }
 
     // Fallback to file-based rate limiting
-    $logDir = __DIR__ . '/logs';
+    // project-root/logs
+    $logDir = dirname(__DIR__, 2) . '/logs';
     $logFile = $logDir . '/requests.log';
 
     // Ensure log directory exists


### PR DESCRIPTION
## Summary
- use global exception classes in `RequestErrorLogManager`
- store rate limiter logs in the shared `logs` directory

## Testing
- `php -l src/Logging/RequestErrorLogManager.php` *(fails: command not found)*
- `php -l src/RateLimit/ipRateLimiter.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68570eaea0c883279d94de4bbfa28cf2