### PR TITLE
Fix error logger path

### DIFF
--- a/public/api/validate.php
+++ b/public/api/validate.php
@@ -47,7 +47,7 @@ try {
     ]);
 } catch (Throwable $e) {
     $errorId = bin2hex(random_bytes(4));
-    $logger  = new RequestErrorLogManager(__DIR__ . '/../../logs', 'request_errors.log');
+    $logger  = new RequestErrorLogManager(dirname(__DIR__, 3) . '/logs', 'request_errors.log');
     $logger->logError(
         $e->getCode(),
         $e->getMessage() . "\n" . $e->getTraceAsString(),


### PR DESCRIPTION
## Summary
- correct error logger path in API

## Testing
- `php -l public/api/validate.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6857159ee0248327b8b478f17ab7e4a5