### PR TITLE
Fix log path and confirm logger imports

### DIFF
--- a/public/api/validate.php
+++ b/public/api/validate.php
@@ -47,7 +47,7 @@ try {
     ]);
 } catch (Throwable $e) {
     $errorId = bin2hex(random_bytes(4));
-    $logger  = new RequestErrorLogManager(dirname(__DIR__, 3) . '/logs', 'request_errors.log');
+    $logger  = new RequestErrorLogManager(dirname(__DIR__, 2) . '/logs', 'request_errors.log');
     $logger->logError(
         $e->getCode(),
         $e->getMessage() . "\n" . $e->getTraceAsString(),


### PR DESCRIPTION
## Summary
- update validate API to log in project logs folder
- confirm built-in exception imports for RequestErrorLogManager

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68571e14165083279ce1d3142d0369d7