### PR TITLE
Fix log path in API handler

### DIFF
--- a/src/AI/promptApiProcessor.php
+++ b/src/AI/promptApiProcessor.php
@@ -22,7 +22,11 @@ function buildInstruction(): string {
 }
 
 function callOpenRouterAPI(string $instruction, string $idea): array {
-    $logger = new RequestErrorLogManager();
+    // point the logger at your project-root "logs" folder
+    $logger = new RequestErrorLogManager(
+        dirname(__DIR__, 2) . '/logs',
+        'request_errors.log'
+    );
     if (!defined('OPENROUTER_API_KEY') || OPENROUTER_API_KEY === '') {
         $logger->logError(500, 'Missing OpenRouter API key');
         throw new Exception('Missing OpenRouter API key.');


### PR DESCRIPTION
## Summary
- ensure promptApiProcessor logs errors into project `logs` directory

## Testing
- `php -l src/AI/promptApiProcessor.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68572cd3fdc48327a8f5592d1176a109