### PR TITLE
Fix parseAIResponse include

### DIFF
--- a/public/api/validate.php
+++ b/public/api/validate.php
@@ -1,5 +1,7 @@
 <?php
 require __DIR__ . '/../../vendor/autoload.php';
+// bring in the parseAIResponse helper
+require_once __DIR__ . '/../../src/AI/responseParser.php';
 use QuickIdeaValidator\Logging\RequestErrorLogManager;
 
 


### PR DESCRIPTION
## Summary
- include `responseParser.php` in `public/api/validate.php`

## Testing
- `composer --version`

------
https://chatgpt.com/codex/tasks/task_e_685742fec6888327b84f226efab911eb