### PR TITLE
Add privacy and terms pages

### DIFF
--- a/public/assets/responsiveFormComponents.css
+++ b/public/assets/responsiveFormComponents.css
@@ -23,6 +23,11 @@ body {
   flex-direction: column;
 }
 
+a,
+a:visited {
+  color: #fff;
+}
+
 .site-header {
   text-align: center;
   padding: 2rem 1rem 1rem;

--- a/public/index.php
+++ b/public/index.php
@@ -12,7 +12,7 @@ $csrf_token = $_SESSION['csrf_token'];
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Quick Idea Validator</title>
+    <title>Validate Your Idea Instantly</title>
     <link rel="stylesheet" href="assets/responsiveFormComponents.css">
 </head>
 <body>
@@ -22,7 +22,7 @@ $csrf_token = $_SESSION['csrf_token'];
       alt="Quick Idea Validator"
       class="banner-img"
     />
-    <h1>Quick Idea Validator</h1>
+    <h1>Validate Your Idea Instantly</h1>
     <p class="instructions">Enter your idea below and get instant AI feedback. Nothing is stored or saved.</p>
   </header>
 
@@ -54,7 +54,7 @@ $csrf_token = $_SESSION['csrf_token'];
   <script src="assets/formSubmissionController.js" defer></script>
 
   <footer>
-    <p>&copy; <?php echo date('Y'); ?> Quick Idea Validator. <a href="privacy.html">Privacy</a> | <a href="terms.html">Terms</a></p>
+    <p>&copy; <?php echo date('Y'); ?> Quick Idea Validator. <a href="privacy.php">Privacy</a> | <a href="terms.php">Terms</a></p>
   </footer>
 </body>
 </html>

--- a/public/privacy.php
+++ b/public/privacy.php
@@ -1,0 +1,27 @@
+<?php
+require_once __DIR__ . '/../vendor/autoload.php';
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Privacy Policy - Quick Idea Validator</title>
+    <link rel="stylesheet" href="assets/responsiveFormComponents.css">
+</head>
+<body>
+  <header class="site-header">
+    <img src="assets/images/quick-idea-validator-banner.png" alt="Quick Idea Validator" class="banner-img" />
+    <h1>Privacy Policy</h1>
+  </header>
+  <main class="app-main">
+    <div class="idea-form">
+      <p>This demo site does not store or inspect any ideas you submit. All data is discarded after processing.</p>
+      <p>Your submissions are used solely to generate a response from the OpenRouter API.</p>
+    </div>
+  </main>
+  <footer>
+    <p>&copy; <?php echo date('Y'); ?> Quick Idea Validator. <a href="privacy.php">Privacy</a> | <a href="terms.php">Terms</a></p>
+  </footer>
+</body>
+</html>

--- a/public/terms.php
+++ b/public/terms.php
@@ -1,0 +1,27 @@
+<?php
+require_once __DIR__ . '/../vendor/autoload.php';
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Terms of Use - Quick Idea Validator</title>
+    <link rel="stylesheet" href="assets/responsiveFormComponents.css">
+</head>
+<body>
+  <header class="site-header">
+    <img src="assets/images/quick-idea-validator-banner.png" alt="Quick Idea Validator" class="banner-img" />
+    <h1>Terms of Use</h1>
+  </header>
+  <main class="app-main">
+    <div class="idea-form">
+      <p>This service is provided for demonstration purposes only. Ideas are processed transiently and are not saved.</p>
+      <p>By using this site you agree that your data may be sent to third-party APIs to generate a response.</p>
+    </div>
+  </main>
+  <footer>
+    <p>&copy; <?php echo date('Y'); ?> Quick Idea Validator. <a href="privacy.php">Privacy</a> | <a href="terms.php">Terms</a></p>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Privacy Policy and Terms of Use pages
- change index heading and document title
- style links to appear white

## Testing
- `composer --version` *(fails: command not found)*
- `php -l public/index.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68575cba95b48327b0925bad9815e9da